### PR TITLE
`reason` was passed to onWebSocketClose, but was not being displayed

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -721,6 +721,8 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 
   @Override
   public final void onWebsocketClose(WebSocket conn, int code, String reason, boolean remote) {
+    // fix: reason display suppressed by removeConnection(conn) or onClose(...)
+		log.error(reason);   // added
     selector.wakeup();
     try {
       if (removeConnection(conn)) {

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -722,7 +722,8 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   @Override
   public final void onWebsocketClose(WebSocket conn, int code, String reason, boolean remote) {
     // fix: reason display suppressed by removeConnection(conn) or onClose(...)
-		log.error(reason);   // added
+	  if (reason != null)                      // added
+		log.error("Reason: " + reason);   // added
     selector.wakeup();
     try {
       if (removeConnection(conn)) {


### PR DESCRIPTION
`reason` was passed to onWebSocketClose, but (under some circumstances?) was never being displayed - most confusing!


## Description
Added a log error line displaying `reason`

## Related Issue
#1097

## Motivation and Context
During debugging, I kept getting messages saying that the connection had been closed..., but not why.  Looking at the code, I found that the reason was in fact getting passed to onWebSocketClose, but was never displayed.

This is my first PR!  I am not sure if this is the best way to handle this problem (although the fix did what was needed), so it would be good if someone could review it!
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
